### PR TITLE
node_modules added in gitignore and bodyparser lib removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "fs": "^0.0.1-security",
     "jsonwebtoken": "^8.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,8 @@
-// import Express from 'express'
-// import BodyParser from 'body-parser'
-// import bodyParser from 'body-parser'
 const express = require('express')
-const bodyParser = require('body-parser')
 const app = express()
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.json());
 
 require('./app/controllers/index.js')(app);
 
-
 app.listen(3000)
-


### PR DESCRIPTION
node_modules is a folder that is created after use the _npm install_ command. 

body-parser isn't necessary to install, declare and use the way it was. It is already imported on express lib.